### PR TITLE
subtract the used balance from the "memo" 

### DIFF
--- a/createbridge.cpp
+++ b/createbridge.cpp
@@ -69,9 +69,7 @@ public:
     /**********************************************/
 
     void createFreeAccount(string& memo, name& account, authority& auth, asset& ram, string& id){
-        asset cpu(0'4000, S_SYS);
-        asset net(0'1000, S_SYS);
-        createAccount(account, auth, ram, net, cpu);
+        createAccount(account, auth, ram, NET, CPU);
 
         subBalance(id, ram + asset(0'5000, S_SYS));
 
@@ -108,17 +106,16 @@ public:
             }
         }
 
-        asset leftover = fromPayer - ramFromPayer;
-        asset cpu(((float)leftover.amount * 0.8), S_SYS);
-        asset net(((float)leftover.amount * 0.2), S_SYS);
+        asset requiredBalance = ramFromPayer + CPU + NET;
 
-        if(!hasBalance(memo, ram + cpu + net)){
+        if(!hasBalance(memo, requiredBalance)){
             eosio_assert(false, "Not enough to pay for account.");
         }
 
-        createAccount(account, auth, ram, net, cpu);
+        createAccount(account, auth, ram, NET, CPU);
 
-        subBalance(memo, fromPayer);
+        subBalance(memo, requiredBalance);
+
         if(ramFromDapp.amount > 0){
             subBalance(origin, ramFromDapp);
         }

--- a/lib/common.h
+++ b/lib/common.h
@@ -8,7 +8,7 @@ using std::string;
 using std::vector;
 
 namespace common {
-    static const symbol S_SYS = symbol("SYS", 4);
+    static const symbol S_SYS = symbol("EOS", 4);
     static const symbol S_RAM = symbol("RAMCORE", 4);
     static asset CPU(0'4000, S_SYS);
     static asset NET(0'1000, S_SYS);

--- a/lib/common.h
+++ b/lib/common.h
@@ -8,9 +8,10 @@ using std::string;
 using std::vector;
 
 namespace common {
-
-    static const symbol S_SYS = symbol("EOS", 4);
+    static const symbol S_SYS = symbol("SYS", 4);
     static const symbol S_RAM = symbol("RAMCORE", 4);
+    static asset CPU(0'4000, S_SYS);
+    static asset NET(0'1000, S_SYS);
 
     inline static uint64_t toUUID(string username){
         return std::hash<string>{}(username);


### PR DESCRIPTION
- Currently, for partially funded accounts in createJointAccounts, the remaining balance from the funding account is used up to buy cpu and ram.

- Change the code to subtract the balance used for creating new partially funded accounts from the available balance.

- Instead of staking the remaining balance for cpu/net, stake a constant amount for cpu and net.
