### PR TITLE
add actions to register a dapp and owner account with the contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ If you are an app you can send the `createbridge` contract funds with your `orig
 
 ### Define an account name for your dapp
 
-If you are a dapp, you can define a unique identifier for the dapp and register the `owner` account name for the dapp. Also, you can specify the amount of EOS for ram, net and cpu (in order) to give to the new user accounts. Only the owner account/ whitelisted accounts would be able to create new user accounts for your dapp. 
-- `cleos push action createbridge define '[YOUR_ACCOUNT,"dapp_name",ram,net,cpu]'`
+If you are an app, you can define a unique identifier for the dapp and register the `owner` account name for the dapp. Also, you can specify the amount of EOS for ram, net and cpu (in order) to give to the new user accounts. Only the owner account/ whitelisted accounts would be able to create new user accounts for your dapp. 
+- `cleos push action createbridge define '[YOUR_ACCOUNT,app_name,ram,net,cpu]'`
 
 ### Whitelist other accounts
 
 You can whitelist other accounts, to create account on behalf of your dapp.
--  `cleos push action createbridge whitelist '[YOUR_ACCOUNT,ACCOUNT_NAME,"dapp_name"]'`
+-  `cleos push action createbridge whitelist '[YOUR_ACCOUNT,ACCOUNT_NAME,app_name]'`
 
 ### Partial Costs
 
-You can assume just 50% of the RAM costs for an account.
-- `cleos transfer YOUR_ACCOUNT createbridge "10.0000 EOS" "everipedia.org"`
+You can specify the app you want to contribute to along with the percentage of RAM cost you want to contribute, separated by comma in the memo field for transfer action.
+- `cleos transfer YOUR_ACCOUNT createbridge "10.0000 EOS" "everipedia.org,50"`
 
 ### Full Costs
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This is an EOSIO account creator contract that allows apps to assume portions of
 
 If you are an app you can send the `createbridge` contract funds with your `origin` as the memo to allocate some funds which will be used to pay for 1/2 of the user's account's RAM.
 
-### Register an account name for your dapp
+### Define an account name for your dapp
 
-If you are a dapp, you can claim a unique identifier for the dapp and register the `owner` account name for the dapp. Also, you can specify the amount of EOS for ram, net and cpu (in order) to give to the new user accounts. Only the owner account/ whitelisted accounts would be able to create new user accounts for your dapp. 
-- `cleos push action createbridge claim '[YOUR_ACCOUNT,"dapp_name",ram,net,cpu]'`
+If you are a dapp, you can define a unique identifier for the dapp and register the `owner` account name for the dapp. Also, you can specify the amount of EOS for ram, net and cpu (in order) to give to the new user accounts. Only the owner account/ whitelisted accounts would be able to create new user accounts for your dapp. 
+- `cleos push action createbridge define '[YOUR_ACCOUNT,"dapp_name",ram,net,cpu]'`
 
 ### Whitelist other accounts
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,17 @@
 This is an EOSIO account creator contract that allows apps to assume portions of the costs for account creation.
 
 
-If you are an app you can send the `createbridge` contract funds with your `origin` as the memo to allocate some funds which
-will be used to pay for 1/2 of the user's account's RAM.
+If you are an app you can send the `createbridge` contract funds with your `origin` as the memo to allocate some funds which will be used to pay for 1/2 of the user's account's RAM.
 
+### Register an account name for your dapp
+
+If you are a dapp, you can claim a unique identifier for the dapp and register the `owner` account name for the dapp. Also, you can specify the amount of EOS for ram, net and cpu (in order) to give to the new user accounts. Only the owner account/ whitelisted accounts would be able to create new user accounts for your dapp. 
+- `cleos push action createbridge claim '[YOUR_ACCOUNT,"dapp_name",ram,net,cpu]'`
+
+### Whitelist other accounts
+
+You can whitelist other accounts, to create account on behalf of your dapp.
+-  `cleos push action createbridge whitelist '[YOUR_ACCOUNT,ACCOUNT_NAME,"dapp_name"]' -p app.apim@active`
 
 ### Partial Costs
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are a dapp, you can define a unique identifier for the dapp and register 
 ### Whitelist other accounts
 
 You can whitelist other accounts, to create account on behalf of your dapp.
--  `cleos push action createbridge whitelist '[YOUR_ACCOUNT,ACCOUNT_NAME,"dapp_name"]' -p app.apim@active`
+-  `cleos push action createbridge whitelist '[YOUR_ACCOUNT,ACCOUNT_NAME,"dapp_name"]'`
 
 ### Partial Costs
 

--- a/createbridge.cpp
+++ b/createbridge.cpp
@@ -50,7 +50,6 @@ public:
             row.ram = ram;
             row.net = net;
             row.cpu = cpu;
-            row.buy = buy;
         }); else {
             auto msg = "the dapp " + dapp + " is already registered by another account";
             eosio_assert(false, msg.c_str());
@@ -70,7 +69,6 @@ public:
             auto msg = "the dapp " + dapp + " is not owned by account " + owner.to_string();
             eosio_assert(false, msg.c_str());
         }
-
     }
 
     ACTION create(string& memo, name& account, public_key& key, string& origin){

--- a/createbridge.cpp
+++ b/createbridge.cpp
@@ -40,7 +40,7 @@ public:
 
     // Called to claim an account name as the owner of a dapp. 
     // Only the owner account/whitelisted account will be able to create new user account for the dapp 
-    ACTION claim(name& owner, string dapp, asset ram, asset net, asset cpu, bool buy) {
+    ACTION define(name& owner, string dapp, asset ram, asset net, asset cpu, bool buy) {
         require_auth(owner);
         Dappregistry dapps(_self, _self.value);
         auto iterator = dapps.find(toUUID(dapp));
@@ -282,7 +282,7 @@ void apply(uint64_t receiver, uint64_t code, uint64_t action) {
     auto self = receiver;
 
     if( code == self ) switch(action) {
-        EOSIO_DISPATCH_HELPER( createbridge, (clean)(create)(claim)(whitelist) )
+        EOSIO_DISPATCH_HELPER( createbridge, (clean)(create)(define)(whitelist) )
     }
 
     else {

--- a/lib/common.h
+++ b/lib/common.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <sstream>
+#include <string>
+
 #include <eosiolib/eosio.hpp>
 #include <eosiolib/asset.hpp>
 
@@ -17,7 +20,15 @@ namespace common {
         return std::hash<string>{}(username);
     }
 
-
+   std::vector<std::string> split(const std::string &s, char delim) {
+        std::stringstream ss(s);
+        std::string item;
+        std::vector<std::string> elems;
+        while (std::getline(ss, item, delim)) {
+            elems.push_back(item);
+        }
+        return elems;
+    }
 
     struct rammarket {
         asset    supply;

--- a/models/balances.h
+++ b/models/balances.h
@@ -14,8 +14,15 @@ namespace balances {
 
     typedef eosio::multi_index<"dappregistry"_n, dappregistry> Dappregistry;
 
+    struct [[eosio::table, eosio::contract("createbridge")]] contributors {
+        name contributor;
+        asset balance;
+        int ram;   // percentage of ram cost the contributor wants to fund
+    };
+
     struct [[eosio::table, eosio::contract("createbridge")]] balances {
         uint64_t memo;
+        vector<contributors> contributors;
         asset balance;
         string origin;
         uint64_t timestamp;

--- a/models/balances.h
+++ b/models/balances.h
@@ -1,13 +1,13 @@
 #pragma once
 
 namespace balances {
+
     struct [[eosio::table, eosio::contract("createbridge")]] dappregistry {
         name owner;
         string dapp;
         asset ram; // ram in addition to the minimum required for account creation to put in the new user account created for the dapp
         asset net; // SYS/EOS amount to be staked/spent for net
         asset cpu; // SYS/EOS amount to be staked/spent for cpu
-        bool buy;  // specify whether to stake or buy the net and cpu for the new user account for the dapp
         vector<name> whitelisted_accounts;
         uint64_t primary_key() const {return common::toUUID(dapp);}
     };

--- a/models/balances.h
+++ b/models/balances.h
@@ -1,6 +1,18 @@
 #pragma once
 
 namespace balances {
+    struct [[eosio::table, eosio::contract("createbridge")]] dappregistry {
+        name owner;
+        string dapp;
+        asset ram; // ram in addition to the minimum required for account creation to put in the new user account created for the dapp
+        asset net; // SYS/EOS amount to be staked/spent for net
+        asset cpu; // SYS/EOS amount to be staked/spent for cpu
+        bool buy;  // specify whether to stake or buy the net and cpu for the new user account for the dapp
+        vector<name> whitelisted_accounts;
+        uint64_t primary_key() const {return common::toUUID(dapp);}
+    };
+
+    typedef eosio::multi_index<"dappregistry"_n, dappregistry> Dappregistry;
 
     struct [[eosio::table, eosio::contract("createbridge")]] balances {
         uint64_t memo;


### PR DESCRIPTION
- add "claim" action to register a dapp along with its owner account.  This creates a record in the dappregistry table so that only the owner account/whitelisted account can create new user accounts for the dapp. 

- add "whitelist" action to allow owner account of dapps to whitelist other accounts. 