### PR TITLE
edit transfer function to record individual contributions for an app

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@ If you are an app you can send the `createbridge` contract funds with your `orig
 
 ### Define an account name for your dapp
 
-If you are a dapp, you can define a unique identifier for the dapp and register the `owner` account name for the dapp. Also, you can specify the amount of EOS for ram, net and cpu (in order) to give to the new user accounts. Only the owner account/ whitelisted accounts would be able to create new user accounts for your dapp. 
-- `cleos push action createbridge define '[YOUR_ACCOUNT,"dapp_name",ram,net,cpu]'`
+If you are an app, you can define a unique identifier for the dapp and register the `owner` account name for the dapp. Also, you can specify the amount of EOS for ram, net and cpu (in order) to give to the new user accounts. Only the owner account/ whitelisted accounts would be able to create new user accounts for your dapp. 
+- `cleos push action createbridge define '[YOUR_ACCOUNT,app_name,ram,net,cpu]'`
 
 ### Whitelist other accounts
 
 You can whitelist other accounts, to create account on behalf of your dapp.
--  `cleos push action createbridge whitelist '[YOUR_ACCOUNT,ACCOUNT_NAME,"dapp_name"]'`
+-  `cleos push action createbridge whitelist '[YOUR_ACCOUNT,ACCOUNT_NAME,app_name]'`
 
 ### Partial Costs
 
-You can assume just 50% of the RAM costs for an account.
-- `cleos transfer YOUR_ACCOUNT createbridge "10.0000 EOS" "everipedia.org"`
+You can specify the app you want to contribute to along with the percentage of RAM cost you want to contribute, separated by comma in the memo field for transfer action.
+- `cleos transfer YOUR_ACCOUNT createbridge "10.0000 EOS" "everipedia.org,50"`
 
 ### Full Costs
 

--- a/lib/common.h
+++ b/lib/common.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <sstream>
+#include <string>
+
 #include <eosiolib/eosio.hpp>
 #include <eosiolib/asset.hpp>
 
@@ -17,7 +20,15 @@ namespace common {
         return std::hash<string>{}(username);
     }
 
-
+   std::vector<std::string> split(const std::string &s, char delim) {
+        std::stringstream ss(s);
+        std::string item;
+        std::vector<std::string> elems;
+        while (std::getline(ss, item, delim)) {
+            elems.push_back(item);
+        }
+        return elems;
+    }
 
     struct rammarket {
         asset    supply;

--- a/models/balances.h
+++ b/models/balances.h
@@ -14,8 +14,15 @@ namespace balances {
 
     typedef eosio::multi_index<"dappregistry"_n, dappregistry> Dappregistry;
 
+    struct [[eosio::table, eosio::contract("createbridge")]] contributors {
+        name contributor;
+        asset balance;
+        int ram;   // percentage of ram cost the contributor wants to fund
+    };
+
     struct [[eosio::table, eosio::contract("createbridge")]] balances {
         uint64_t memo;
+        vector<contributors> contributors;
         asset balance;
         string origin;
         uint64_t timestamp;


### PR DESCRIPTION
- Currently all the contributions towards an app gets added to a single balance against the app name in the balance table

- edit the transfer function to record individual contributions and their contributors for an app. And also let them specify the percentage of ram cost they want to subsidize.

 